### PR TITLE
Improve access token lookup query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Improved index to improve access token lookup, run `$ rails zaikio_oauth_client:install:migrations` to apply
+* Simplified and improve order of conditions in Access Token lookup
 
 ## 0.5.1
 

--- a/test/zaikio/oauth_client_test.rb
+++ b/test/zaikio/oauth_client_test.rb
@@ -73,6 +73,24 @@ class Zaikio::OAuthClient::Test < ActiveSupport::TestCase
     assert_equal Zaikio::OAuthClient.configuration.host, client_config.oauth_client.site
   end
 
+  test "gets valid access token without refresh token" do
+    Zaikio::JWTAuth.stubs(:revoked_token_ids).returns([])
+    access_token = Zaikio::AccessToken.create!(
+      bearer_type: "Organization",
+      bearer_id: "123",
+      audience: "warehouse",
+      token: "abc",
+      expires_at: 1.hour.from_now,
+      scopes: %w[directory.organization.r directory.something.r]
+    )
+
+    assert_equal access_token, Zaikio::OAuthClient.get_access_token(
+      bearer_type: "Organization",
+      bearer_id: "123",
+      scopes: %w[directory.something.r]
+    )
+  end
+
   test "gets valid access token" do
     Zaikio::JWTAuth.stubs(:revoked_token_ids).returns([])
     access_token = Zaikio::AccessToken.create!(


### PR DESCRIPTION
Query now:

```sql
SELECT "zaikio_access_tokens".* FROM "zaikio_access_tokens" WHERE "zaikio_access_tokens"."audience" = $1 AND "zaikio_access_tokens"."bearer_type" = $2 AND "zaikio_access_tokens"."bearer_id" = $3 AND 1=1 AND (expires_at > '2021-02-23 08:23:07.681496' OR (expires_at <= '2021-02-23 08:23:07.681873' AND created_at > '2021-02-16 08:23:07.681878') AND (refresh_token IS NOT NULL)) AND (scopes @> ARRAY['directory.something.r']::varchar[]) ORDER BY "zaikio_access_tokens"."expires_at" DESC LIMIT $4
```