### PR TITLE
Use requested scopes in access token lookup instead of actual scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fixed token lookup by searching through requested scopes not through granted scopes. You need to run `$ rails zaikio_oauth_client:install:migrations` to apply latest migrations.
+
 ## 0.6.0
 
 * Improved index to improve access token lookup, run `$ rails zaikio_oauth_client:install:migrations` to apply

--- a/app/models/zaikio/access_token.rb
+++ b/app/models/zaikio/access_token.rb
@@ -40,9 +40,9 @@ module Zaikio
         .where("refresh_token IS NOT NULL")
         .where.not(id: Zaikio::JWTAuth.revoked_token_ids)
     }
-    scope :by_bearer, lambda { |bearer_id:, scopes: [], bearer_type: "Person"|
+    scope :by_bearer, lambda { |bearer_id:, requested_scopes: [], bearer_type: "Person"|
       where(bearer_type: bearer_type, bearer_id: bearer_id)
-        .where("requested_scopes @> ARRAY[?]::varchar[]", scopes)
+        .where("requested_scopes @> ARRAY[?]::varchar[]", requested_scopes)
     }
     scope :usable, lambda { |options|
       by_bearer(**options).valid.or(by_bearer(**options).valid_refresh)

--- a/db/migrate/20210224154303_add_requested_scopes_to_zaikio_access_tokens.rb
+++ b/db/migrate/20210224154303_add_requested_scopes_to_zaikio_access_tokens.rb
@@ -1,0 +1,6 @@
+class AddRequestedScopesToZaikioAccessTokens < ActiveRecord::Migration[6.1]
+  def change
+    add_column :zaikio_access_tokens, :requested_scopes, :string, array: true, default: [], null: false
+    Zaikio::AccessToken.update_all("requested_scopes = scopes")
+  end
+end

--- a/db/migrate/20210224154303_add_requested_scopes_to_zaikio_access_tokens.rb
+++ b/db/migrate/20210224154303_add_requested_scopes_to_zaikio_access_tokens.rb
@@ -1,6 +1,6 @@
 class AddRequestedScopesToZaikioAccessTokens < ActiveRecord::Migration[6.1]
   def change
     add_column :zaikio_access_tokens, :requested_scopes, :string, array: true, default: [], null: false
-    Zaikio::AccessToken.update_all("requested_scopes = scopes")
+    Zaikio::AccessToken.update_all("requested_scopes = scopes, updated_at = now()")
   end
 end

--- a/lib/zaikio/oauth_client.rb
+++ b/lib/zaikio/oauth_client.rb
@@ -72,7 +72,8 @@ module Zaikio
               bearer_type: bearer_type,
               bearer_id: bearer_id,
               scopes: scopes
-            )
+            ),
+            requested_scopes: scopes
           )
           access_token.save!
         elsif access_token&.expired?

--- a/lib/zaikio/oauth_client.rb
+++ b/lib/zaikio/oauth_client.rb
@@ -63,7 +63,11 @@ module Zaikio
         scopes ||= client_config.default_scopes_for(bearer_type)
 
         access_token = Zaikio::AccessToken.where(audience: client_config.client_name)
-                                          .usable(bearer_type: bearer_type, bearer_id: bearer_id, scopes: scopes)
+                                          .usable(
+                                            bearer_type: bearer_type,
+                                            bearer_id: bearer_id,
+                                            requested_scopes: scopes
+                                          )
                                           .first
 
         if access_token.blank?

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -49,10 +49,10 @@ module Zaikio
       def create_access_token
         access_token_response = oauth_client.auth_code.get_token(params[:code])
 
-        access_token = Zaikio::AccessToken.build_from_access_token(access_token_response)
-        access_token.save!
-
-        access_token
+        Zaikio::AccessToken.build_from_access_token(
+          access_token_response,
+          requested_scopes: client_config.default_scopes
+        ).tap(&:save!)
       end
 
       def client_name

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_22_135920) do
+ActiveRecord::Schema.define(version: 2021_02_24_154303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_135920) do
     t.string "scopes", default: [], null: false, array: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "requested_scopes", default: [], null: false, array: true
     t.index ["audience", "bearer_type", "bearer_id"], name: "zaikio_access_tokens_lookup_index"
     t.index ["expires_at"], name: "index_zaikio_access_tokens_on_expires_at"
     t.index ["refresh_token"], name: "index_zaikio_access_tokens_on_refresh_token", unique: true

--- a/test/zaikio/oauth_client_test.rb
+++ b/test/zaikio/oauth_client_test.rb
@@ -82,7 +82,8 @@ class Zaikio::OAuthClient::Test < ActiveSupport::TestCase
       token: "abc",
       refresh_token: "def",
       expires_at: 1.hour.from_now,
-      scopes: %w[directory.organization.r directory.something.r]
+      scopes: %w[directory.organization.r],
+      requested_scopes: %w[directory.organization.r directory.something.r]
     )
 
     assert_equal access_token, Zaikio::OAuthClient.get_access_token(
@@ -102,7 +103,8 @@ class Zaikio::OAuthClient::Test < ActiveSupport::TestCase
       token: "abc",
       refresh_token: "def",
       expires_at: 10.hours.from_now,
-      scopes: %w[directory.organization.r directory.something.r]
+      scopes: %w[directory.organization.r directory.something.r],
+      requested_scopes: %w[directory.organization.r directory.something.r]
     )
     access_token2 = Zaikio::AccessToken.create!(
       bearer_type: "Organization",
@@ -111,7 +113,8 @@ class Zaikio::OAuthClient::Test < ActiveSupport::TestCase
       token: "def",
       refresh_token: "ghi",
       expires_at: 1.hour.from_now,
-      scopes: %w[directory.organization.r directory.something.r]
+      scopes: %w[directory.organization.r directory.something.r],
+      requested_scopes: %w[directory.organization.r directory.something.r]
     )
 
     assert_equal access_token2, Zaikio::OAuthClient.get_access_token(
@@ -131,7 +134,8 @@ class Zaikio::OAuthClient::Test < ActiveSupport::TestCase
       token: "abc",
       refresh_token: "def",
       expires_at: 10.hours.from_now,
-      scopes: %w[directory.organization.r directory.something.r]
+      scopes: %w[directory.organization.r directory.something.r],
+      requested_scopes: %w[directory.organization.r directory.something.r]
     )
     access_token2 = Zaikio::AccessToken.create!(
       bearer_type: "Organization",
@@ -140,7 +144,8 @@ class Zaikio::OAuthClient::Test < ActiveSupport::TestCase
       token: "def",
       refresh_token: "ghi",
       expires_at: 1.hour.from_now,
-      scopes: %w[directory.organization.r directory.something.r]
+      scopes: %w[directory.organization.r directory.something.r],
+      requested_scopes: %w[directory.organization.r directory.something.r]
     )
 
     Zaikio::OAuthClient.with_client("other_app") do
@@ -161,7 +166,8 @@ class Zaikio::OAuthClient::Test < ActiveSupport::TestCase
       token: "abc",
       refresh_token: "def",
       expires_at: 1.hour.ago,
-      scopes: %w[directory.organization.r directory.something.r]
+      scopes: %w[directory.organization.r directory.something.r],
+      requested_scopes: %w[directory.organization.r directory.something.r]
     )
 
     stub_request(:post, "http://hub.zaikio.test/oauth/access_token")


### PR DESCRIPTION
Currently when for example requesting `directory.organization.r,warehouse.something.r` it might be that `warehouse.something.r` is not available because there is no installation of `warehouse`. In that case we will keep creating new access tokens because the `warehouse.something` scope is not included in the list of scopes.

Furthermore with this logic we can easily check which integrations are missing for the user.

This PR adds a new column `requested_scopes` (prefilled with current scopes column) and changes the lookup accordingly.