### PR TITLE
Only lookup Hub::Models module under Zaikio::

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.7.1 - 2021-03-17
+
+* Fix incorrect const_defined? behaviour when initializing without zaikio-hub-models gem
+
 ## 0.7.0
 
 * Don't set `cookies.encrypted[:origin]` when passing `?origin` to `new_session_path`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zaikio-oauth_client (0.7.0)
+    zaikio-oauth_client (0.7.1)
       oauth2
       rails (>= 5.0.0)
       zaikio-jwt_auth (>= 0.2.1, < 0.5.0)
@@ -133,7 +133,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (3.11.2)
+    oj (3.11.3)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)

--- a/app/models/zaikio/access_token.rb
+++ b/app/models/zaikio/access_token.rb
@@ -62,7 +62,7 @@ module Zaikio
     end
 
     def bearer_klass
-      return unless Zaikio.const_defined?("Hub::Models")
+      return unless Zaikio.const_defined?("Hub::Models", false)
 
       if Zaikio::Hub::Models.configuration.respond_to?(:"#{bearer_type.underscore}_class_name")
         Zaikio::Hub::Models.configuration.public_send(:"#{bearer_type.underscore}_class_name").constantize

--- a/lib/zaikio/oauth_client/version.rb
+++ b/lib/zaikio/oauth_client/version.rb
@@ -1,5 +1,5 @@
 module Zaikio
   module OAuthClient
-    VERSION = "0.7.0".freeze
+    VERSION = "0.7.1".freeze
   end
 end


### PR DESCRIPTION
`const_defined?` takes two arguments. Given just the following code:

```ruby
  module Zaikio; end
  module Webhooks; end

  Zaikio.const_defined?("Webhooks") => true # wrong
  const_defined?("Webhooks")        => true # correct
```

We only want to find any `Webhooks` module _inside_ the Zaikio namespace, not the top-level one. We need to pass a second argument, `false`, to tell it to not recurse upwards until it finds something.

This was breaking in the Hub, where the zaikio-webhooks gem is not loaded.