### PR TITLE
Allow defining an error handler when approval fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,30 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+#### Handling errors
+
+Occasionally, there might be an OAuth error when trying to approve a connection. For
+example:
+
+> The application, grant, refresh token or device authorization could not be found
+
+(which happens when trying to replay the same authorization, e.g. refreshing the page).
+
+If you'd like to define a custom error handler to happen in these sorts of situation, you
+can configure a Proc object which receives the `exception` as a parameter and runs in the
+context of a controller. For example:
+
+```ruby
+Zaikio::OAuthClient.configure do |config|
+  config.register_client :warehouse do |warehouse|
+    warehouse.oauth_error_handler = lambda do |exception|
+      flash[:error] = exception.message
+      redirect_to "/"
+    end
+  end
+end
+```
+
 #### Custom behavior
 
 Since the built in `SessionsController` and `ConnectionsController` are inheriting from the main app's `ApplicationController` all behaviour will be added there, too. In some cases you might want to explicitly skip a `before_action` or add custom `before_action` callbacks.

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -26,6 +26,9 @@ module Zaikio
           respond_to?(:after_approve_path_for) ? :after_approve_path_for : :default_after_approve_path_for,
           access_token, origin
         )
+      rescue OAuth2::Error => e
+        handler = client_config.oauth_error_handler
+        handler ? instance_eval(&handler) : raise(e)
       end
 
       def destroy

--- a/lib/zaikio/oauth_client/client_configuration.rb
+++ b/lib/zaikio/oauth_client/client_configuration.rb
@@ -2,7 +2,7 @@ module Zaikio
   module OAuthClient
     class ClientConfiguration
       attr_reader :org_config, :client_name
-      attr_accessor :client_id, :client_secret, :default_scopes
+      attr_accessor :client_id, :client_secret, :default_scopes, :oauth_error_handler
 
       def initialize(client_name)
         @default_scopes = []


### PR DESCRIPTION
I'm not 100% sure this is the best way to solve my problem, but basically we've had quite a few of these in Procurement:

* https://appsignal.com/zaikio/sites/5e5e179b14ad6606236277d1/exceptions/incidents/369
* https://appsignal.com/zaikio/sites/5e5e179b14ad6606236277d1/exceptions/incidents/301
* https://appsignal.com/zaikio/sites/5e5e179b14ad6606236277d1/exceptions/incidents/363
* https://appsignal.com/zaikio/sites/5e5e179b14ad6606236277d1/exceptions/incidents/364

There are also OAuth2 errors when the developer makes a mistake (using an illegal scope, for example), but this one here happens when the user refreshes the page, probably after something else went wrong for them (e.g. another exception elsewhere).

I think we should help them get back to a good state. It would be easy to catch the exception and send them back to the OAuth flow again to get a fresh code, or send them to the homepage with the flash error message, etc.

The alternative to this is defining a global exception handler in your Rails app, e.g.:

```ruby
class ApplicationController
  rescue_from OAuth2::Error, with: :handle_oauth_error

  def handle_oauth_error
    # do something useful
```

I'd be happy to do that, and we should still document here what that developer journey looks like if so.