### PR TITLE
Add Subscription Redirect flow controller & routing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,8 @@ require:
 
 Layout/LineLength:
   Max: 119 # line length on GitHub's PR pages
+  Exclude:
+    - config/routes.rb
 
 Metrics/ClassLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Add support for subscription flow (for setting up a plan)
+
 ## 0.8.1 - 2021-03-31
 
 * Destroy access token with invalid refresh token

--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ redirect_to zaikio_oauth_client.new_session_path(force_login: true)
 redirect_to zaikio_oauth_client.new_session_path(state: "something-my-app-uses")
 ```
 
+You can also send them to the [Subscription Redirect
+flow](https://docs.zaikio.com/api/directory/guides/subscriptions/redirect-flow/), which
+behaves & redirects back like a regular Organization flow except it additionally sets up a
+subscription for the organization:
+
+```ruby
+# Require them to select a plan themselves...
+redirect_to zaikio_oauth_client.new_subscription_path
+
+# Or preselect a plan for them
+redirect_to zaikio_oauth_client.new_subscription_path(plan: "free")
+```
+
 #### Session handling
 
 The Zaikio gem engine will set a cookie for the user after a successful OAuth flow: `cookies.encrypted[:zaikio_person_id]`.

--- a/app/controllers/zaikio/oauth_client/subscriptions_controller.rb
+++ b/app/controllers/zaikio/oauth_client/subscriptions_controller.rb
@@ -1,0 +1,20 @@
+module Zaikio
+  module OAuthClient
+    class SubscriptionsController < ConnectionsController
+      def new
+        opts = params.permit(:client_name, :state, :plan)
+        client_name = opts.delete(:client_name)
+        plan = opts.delete(:plan)
+
+        subscription_scope = "Org.subscription_create"
+        subscription_scope << ".#{plan}" if plan.present?
+
+        redirect_to oauth_client.auth_code.authorize_url(
+          redirect_uri: approve_url(client_name),
+          scope: subscription_scope,
+          **opts
+        )
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,14 @@
 Zaikio::OAuthClient::Engine.routes.draw do
-  sessions_controller = Zaikio::OAuthClient.configuration.sessions_controller_name
-  connections_controller = Zaikio::OAuthClient.configuration.connections_controller_name
+  config = Zaikio::OAuthClient.configuration
 
-  # People
-  get "(/:client_name)/sessions/new", action: :new, controller: sessions_controller, as: :new_session
-  get "(/:client_name)/sessions/approve", action: :approve, controller: sessions_controller, as: :approve_session
-  delete "(/:client_name)/session", action: :destroy, controller: sessions_controller, as: :session
+  scope path: "(/:client_name)" do
+    # People
+    get "/sessions/new",     action: :new,     controller: config.sessions_controller_name, as: :new_session
+    get "/sessions/approve", action: :approve, controller: config.sessions_controller_name, as: :approve_session
+    delete "/session",       action: :destroy, controller: config.sessions_controller_name, as: :session
 
-  # Organizations
-  get "(/:client_name)/connections/new", action: :new,
-                                         controller: connections_controller, as: :new_connection
-  get "(/:client_name)/connections/approve", action: :approve,
-                                             controller: connections_controller, as: :approve_connection
+    # Organizations
+    get "/connections/new",     action: :new,     controller: config.connections_controller_name, as: :new_connection
+    get "/connections/approve", action: :approve, controller: config.connections_controller_name, as: :approve_connection
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,8 @@ Zaikio::OAuthClient::Engine.routes.draw do
     # Organizations
     get "/connections/new",     action: :new,     controller: config.connections_controller_name, as: :new_connection
     get "/connections/approve", action: :approve, controller: config.connections_controller_name, as: :approve_connection
+
+    # Subscriptions
+    get "/subscriptions/new", action: :new, controller: config.subscriptions_controller_name, as: :new_subscription
   end
 end

--- a/lib/zaikio/oauth_client/configuration.rb
+++ b/lib/zaikio/oauth_client/configuration.rb
@@ -15,13 +15,14 @@ module Zaikio
       attr_accessor :host
       attr_writer :logger
       attr_reader :client_configurations, :environment, :around_auth_block,
-                  :sessions_controller_name, :connections_controller_name
+                  :sessions_controller_name, :connections_controller_name, :subscriptions_controller_name
 
       def initialize
         @client_configurations = {}
         @around_auth_block = nil
         @sessions_controller_name = "sessions"
         @connections_controller_name = "connections"
+        @subscriptions_controller_name = "subscriptions"
       end
 
       def logger
@@ -56,6 +57,10 @@ module Zaikio
 
       def connections_controller_name=(name)
         @connections_controller_name = "/#{name}"
+      end
+
+      def subscriptions_controller_name=(name)
+        @subscriptions_controller_name = "/#{name}"
       end
 
       private

--- a/test/controllers/zaikio/oauth_client/routing_test.rb
+++ b/test/controllers/zaikio/oauth_client/routing_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class Zaikio::OAuthClient::RoutingTest < ActionDispatch::IntegrationTest
+  def setup
+    @routes = Zaikio::OAuthClient::Engine.routes
+  end
+
+  include Zaikio::OAuthClient::Engine.routes.url_helpers
+
+  test "routing without client_name" do
+    assert_equal new_session_path, "/zaikio/sessions/new"
+    assert_recognizes({ controller: "sessions", action: "new" }, "/sessions/new")
+
+    assert_equal approve_session_path, "/zaikio/sessions/approve"
+    assert_recognizes({ controller: "sessions", action: "approve" }, "/sessions/approve")
+
+    assert_equal session_path, "/zaikio/session"
+    assert_recognizes({ controller: "sessions", action: "destroy" }, { path: "/session", method: :delete })
+
+    assert_equal new_connection_path, "/zaikio/connections/new"
+    assert_recognizes({ controller: "zaikio/o_auth_client/connections", action: "new" }, "/connections/new")
+
+    assert_equal approve_connection_path, "/zaikio/connections/approve"
+    assert_recognizes({ controller: "zaikio/o_auth_client/connections", action: "approve" }, "/connections/approve")
+  end
+
+  test "routing including a custom :client_name" do
+    assert_equal new_session_path(client_name: "foo"), "/zaikio/foo/sessions/new"
+    assert_recognizes({ controller: "sessions", action: "new", client_name: "foo" }, "/foo/sessions/new")
+
+    assert_equal approve_session_path(client_name: "foo"), "/zaikio/foo/sessions/approve"
+    assert_recognizes({ controller: "sessions", action: "approve", client_name: "foo" }, "/foo/sessions/approve")
+
+    assert_equal session_path(client_name: "foo"), "/zaikio/foo/session"
+    assert_recognizes({ controller: "sessions", action: "destroy", client_name: "foo" },
+                      { path: "/foo/session", method: :delete })
+
+    assert_equal new_connection_path(client_name: "foo"), "/zaikio/foo/connections/new"
+    assert_recognizes({ controller: "zaikio/o_auth_client/connections", action: "new", client_name: "foo" },
+                      "/foo/connections/new")
+
+    assert_equal approve_connection_path(client_name: "foo"), "/zaikio/foo/connections/approve"
+    assert_recognizes({ controller: "zaikio/o_auth_client/connections", action: "approve", client_name: "foo" },
+                      "/foo/connections/approve")
+  end
+end

--- a/test/controllers/zaikio/oauth_client/routing_test.rb
+++ b/test/controllers/zaikio/oauth_client/routing_test.rb
@@ -22,6 +22,9 @@ class Zaikio::OAuthClient::RoutingTest < ActionDispatch::IntegrationTest
 
     assert_equal approve_connection_path, "/zaikio/connections/approve"
     assert_recognizes({ controller: "zaikio/o_auth_client/connections", action: "approve" }, "/connections/approve")
+
+    assert_equal new_subscription_path, "/zaikio/subscriptions/new"
+    assert_recognizes({ controller: "zaikio/o_auth_client/subscriptions", action: "new" }, "/subscriptions/new")
   end
 
   test "routing including a custom :client_name" do
@@ -42,5 +45,9 @@ class Zaikio::OAuthClient::RoutingTest < ActionDispatch::IntegrationTest
     assert_equal approve_connection_path(client_name: "foo"), "/zaikio/foo/connections/approve"
     assert_recognizes({ controller: "zaikio/o_auth_client/connections", action: "approve", client_name: "foo" },
                       "/foo/connections/approve")
+
+    assert_equal new_subscription_path(client_name: "foo"), "/zaikio/foo/subscriptions/new"
+    assert_recognizes({ controller: "zaikio/o_auth_client/subscriptions", action: "new", client_name: "foo" },
+                      "/foo/subscriptions/new")
   end
 end

--- a/test/controllers/zaikio/oauth_client/subscriptions_controller_test.rb
+++ b/test/controllers/zaikio/oauth_client/subscriptions_controller_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+module Zaikio
+  module OAuthClient
+    class SubscriptionsControllerTest < ActionDispatch::IntegrationTest
+      include Engine.routes.url_helpers
+
+      def setup
+        Zaikio::OAuthClient.configure do |config|
+          config.environment = :test
+          config.register_client :warehouse do |warehouse|
+            warehouse.client_id = "abc"
+            warehouse.client_secret = "secret"
+            warehouse.default_scopes = %w[directory.person.r]
+
+            warehouse.register_organization_connection do |org|
+              org.default_scopes = %w[directory.organization.r]
+            end
+          end
+        end
+      end
+
+      test "an unknown org is redirected to the Zaikio OAuth subscription flow" do
+        get zaikio_oauth_client.new_subscription_path
+
+        params = {
+          client_id: "abc",
+          redirect_uri: zaikio_oauth_client.approve_connection_url,
+          response_type: "code",
+          scope: "Org.subscription_create"
+        }
+
+        assert_redirected_to "http://hub.zaikio.test/oauth/authorize?#{params.to_query}"
+      end
+
+      test "with a ?plan parameter it is redirected to the Zaikio OAuth subscription flow" do
+        get zaikio_oauth_client.new_subscription_path(plan: "free")
+
+        params = {
+          client_id: "abc",
+          redirect_uri: zaikio_oauth_client.approve_connection_url,
+          response_type: "code",
+          scope: "Org.subscription_create.free"
+        }
+
+        assert_redirected_to "http://hub.zaikio.test/oauth/authorize?#{params.to_query}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Although this behaves similarly to the ConnectionsController, it only sends a single scope, which may include the plan name, so this required some custom logic.