### PR TITLE
Remove Access Token Lookups Queries from Log by using ActiveSupport::Logger#silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Remove Access Token Lookups Queries from Log
+* Use configured logger for AccessToken queries
+
 ## 0.9.0 - 2021-04-13
 
 * Add support for subscription flow (for setting up a plan)

--- a/lib/zaikio/oauth_client/configuration.rb
+++ b/lib/zaikio/oauth_client/configuration.rb
@@ -13,7 +13,6 @@ module Zaikio
       }.freeze
 
       attr_accessor :host
-      attr_writer :logger
       attr_reader :client_configurations, :environment, :around_auth_block,
                   :sessions_controller_name, :connections_controller_name, :subscriptions_controller_name
 
@@ -23,10 +22,16 @@ module Zaikio
         @sessions_controller_name = "sessions"
         @connections_controller_name = "connections"
         @subscriptions_controller_name = "subscriptions"
+        Zaikio::AccessToken.logger = logger
       end
 
       def logger
-        @logger ||= Logger.new($stdout)
+        @logger ||= ActiveSupport::Logger.new($stdout)
+      end
+
+      def logger=(logger)
+        @logger = logger
+        Zaikio::AccessToken.logger = @logger
       end
 
       def register_client(name)


### PR DESCRIPTION
The lookup queries pollute the log since all revoked ids are included. This adds a small debug log and silence the sql query