### PR TITLE
Set ?state parameter if not given for login, and check it when returning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,7 @@ Metrics/ClassLength:
     - test/**/*.rb
 
 Metrics/MethodLength:
-  Max: 14
+  Max: 15
   Exclude:
     - test/**/*.rb
 
@@ -31,7 +31,7 @@ Metrics/BlockLength:
     - test/**/*.rb
 
 Metrics/AbcSize:
-  Max: 22
+  Max: 25
 
 Metrics/CyclomaticComplexity:
   Max: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Send `redirect_with_error=1` to redirect flow and handle errors like in OAuth spec.
 * Support `error_path_for` for custom error handling.
+* Automatically set `state` parameter for OAuth login and check response to protect
+  against replay attacks.
 
 ## 0.10.0 - 2021-04-15
 

--- a/app/controllers/zaikio/oauth_client/subscriptions_controller.rb
+++ b/app/controllers/zaikio/oauth_client/subscriptions_controller.rb
@@ -4,6 +4,7 @@ module Zaikio
       def new
         opts = params.permit(:client_name, :state, :plan, :organization_id)
         opts[:redirect_with_error] = 1
+        opts[:state] ||= cookies.encrypted[:state] = SecureRandom.urlsafe_base64(32)
 
         plan            = opts.delete(:plan)
         organization_id = opts.delete(:organization_id)

--- a/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
+++ b/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
@@ -23,15 +23,18 @@ module Zaikio
       test "an unknown user is redirected to the Zaikio OAuth flow" do
         get zaikio_oauth_client.new_session_path
 
-        params = {
-          client_id: "abc",
-          redirect_uri: zaikio_oauth_client.approve_session_url,
-          redirect_with_error: 1,
-          response_type: "code",
-          scope: "directory.person.r"
-        }
+        redirect_url = URI.parse(response.headers["Location"])
+        assert_equal "hub.zaikio.test", redirect_url.host
+        assert_equal "/oauth/authorize", redirect_url.path
 
-        assert_redirected_to "http://hub.zaikio.test/oauth/authorize?#{params.to_query}"
+        query = URI.decode_www_form(redirect_url.query).to_h
+        assert_equal query["client_id"], "abc"
+        assert_equal query["redirect_uri"], zaikio_oauth_client.approve_session_url
+        assert_equal query["response_type"], "code"
+        assert_equal query["scope"], "directory.person.r"
+        assert_equal query["redirect_with_error"], "1"
+
+        assert query["state"].present?
       end
 
       test "additional permitted OAuth params are passed into the Zaikio OAuth flow" do


### PR DESCRIPTION
This is a safer default - if applications decline to provide one, we'll set it for them, and automatically check it when the user returns.