### PR TITLE
Use session instead of encrypted cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* **BREAKING CHANGE:** Instead of working `cookies.encrypted` we will switch to `session` because the session cookie will be `httponly` and therefore can prevent XSS attack that set the cookie to another value. See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
+
 ## 0.11.1 - 2021-04-21
 
 * Update zaikio-jwt_auth dependency
@@ -47,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.7.0
 
-* Don't set `cookies.encrypted[:origin]` when passing `?origin` to `new_session_path`
+* Don't set `session[:origin]` when passing `?origin` to `new_session_path`
 * `show_signup`, `force_login` and `state` params are now passed through `new_session_path`.
 
 ## 0.6.1

--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ redirect_to zaikio_oauth_client.new_subscription_path(plan: "free")
 
 #### Session handling
 
-The Zaikio gem engine will set a cookie for the user after a successful OAuth flow: `cookies.encrypted[:zaikio_person_id]`.
+The Zaikio gem engine will set a cookie for the user after a successful OAuth flow: `session[:zaikio_person_id]`.
 
 If you are using for example `Zaikio::Hub::Models`, you can use this snippet to set the current user:
 
 ```ruby
-Current.user ||= Zaikio::Hub::Models::Person.find_by(id: cookies.encrypted[:zaikio_person_id])
+Current.user ||= Zaikio::Hub::Models::Person.find_by(id: session[:zaikio_person_id])
 ````
 
 You can then use `Current.user` anywhere.
@@ -172,7 +172,7 @@ Additionally you can also specify your own redirect handlers in your `Applicatio
 ```rb
 class ApplicationController < ActionController::Base
   def after_approve_path_for(access_token, origin)
-    cookies.encrypted[:zaikio_person_id] = access_token.bearer_id unless access_token.organization?
+    session[:zaikio_person_id] = access_token.bearer_id unless access_token.organization?
 
     # Sync data on login
     Zaikio::Hub.with_token(access_token.token) do
@@ -183,7 +183,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_destroy_path_for(access_token_id)
-    cookies.delete :zaikio_person_id
+    reset_session
 
     main_app.root_path
   end

--- a/app/controllers/zaikio/oauth_client/subscriptions_controller.rb
+++ b/app/controllers/zaikio/oauth_client/subscriptions_controller.rb
@@ -4,7 +4,7 @@ module Zaikio
       def new
         opts = params.permit(:client_name, :state, :plan, :organization_id)
         opts[:redirect_with_error] = 1
-        opts[:state] ||= cookies.encrypted[:state] = SecureRandom.urlsafe_base64(32)
+        opts[:state] ||= session[:state] = SecureRandom.urlsafe_base64(32)
 
         plan            = opts.delete(:plan)
         organization_id = opts.delete(:organization_id)

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -47,7 +47,7 @@ module Zaikio
 
       def destroy
         access_token_id = session[:zaikio_access_token_id]
-        session.delete(:origin)
+        session.delete(:zaikio_access_token_id)
         session.delete(:origin)
 
         redirect_to send(

--- a/lib/zaikio/oauth_client/test_helper.rb
+++ b/lib/zaikio/oauth_client/test_helper.rb
@@ -3,13 +3,52 @@ module Zaikio
     module TestHelper
       extend ActiveSupport::Concern
 
-      def logged_in_as(person)
-        # We need to manually encrypt the value since the tests cookie jar does not
-        # support encrypted or signed cookies
-        encrypted_cookies = ActionDispatch::Request.new(Rails.application.env_config.deep_dup).cookie_jar
-        encrypted_cookies.encrypted[:zaikio_person_id] = person.id
+      class TestSessionController < ActionController::Base
+        def show
+          if session[params[:key]].nil?
+            head :no_content
+          else
+            render plain: session[params[:key]]
+          end
+        end
 
-        cookies["zaikio_person_id"] = encrypted_cookies["zaikio_person_id"]
+        def create
+          session[params[:key]] = params[:id]
+
+          head :ok
+        end
+      end
+
+      def get_session(key)
+        # This is needed as it is not possible to set sesison values in an ActionDispatch::IntegrationTest
+        # This creates a dummy controller to set the session
+        Rails.application.routes.disable_clear_and_finalize = true # Keep existing routes
+        Rails.application.routes.draw do
+          get "/zaikio/oauth_client/test_helper/get_session", to: "zaikio/oauth_client/test_helper/test_session#show"
+        end
+
+        get "/zaikio/oauth_client/test_helper/get_session", params: { key: key }
+
+        if response.status == 204
+          nil
+        else
+          response.body
+        end
+      end
+
+      def set_session(key, value)
+        # This is needed as it is not possible to set sesison values in an ActionDispatch::IntegrationTest
+        # This creates a dummy controller to set the session
+        Rails.application.routes.disable_clear_and_finalize = true # Keep existing routes
+        Rails.application.routes.draw do
+          get "/zaikio/oauth_client/test_helper/session", to: "zaikio/oauth_client/test_helper/test_session#create"
+        end
+
+        get "/zaikio/oauth_client/test_helper/session", params: { id: value, key: key }
+      end
+
+      def logged_in_as(person)
+        set_session(:zaikio_person_id, person.id)
       end
     end
   end

--- a/lib/zaikio/oauth_client/test_helper.rb
+++ b/lib/zaikio/oauth_client/test_helper.rb
@@ -19,14 +19,17 @@ module Zaikio
         end
       end
 
-      def get_session(key)
+      included do
         # This is needed as it is not possible to set sesison values in an ActionDispatch::IntegrationTest
         # This creates a dummy controller to set the session
         Rails.application.routes.disable_clear_and_finalize = true # Keep existing routes
         Rails.application.routes.draw do
           get "/zaikio/oauth_client/test_helper/get_session", to: "zaikio/oauth_client/test_helper/test_session#show"
+          get "/zaikio/oauth_client/test_helper/session", to: "zaikio/oauth_client/test_helper/test_session#create"
         end
+      end
 
+      def get_session(key)
         get "/zaikio/oauth_client/test_helper/get_session", params: { key: key }
 
         if response.status == 204
@@ -37,13 +40,6 @@ module Zaikio
       end
 
       def set_session(key, value)
-        # This is needed as it is not possible to set sesison values in an ActionDispatch::IntegrationTest
-        # This creates a dummy controller to set the session
-        Rails.application.routes.disable_clear_and_finalize = true # Keep existing routes
-        Rails.application.routes.draw do
-          get "/zaikio/oauth_client/test_helper/session", to: "zaikio/oauth_client/test_helper/test_session#create"
-        end
-
         get "/zaikio/oauth_client/test_helper/session", params: { id: value, key: key }
       end
 

--- a/test/controllers/zaikio/oauth_client/subscriptions_controller_test.rb
+++ b/test/controllers/zaikio/oauth_client/subscriptions_controller_test.rb
@@ -69,13 +69,14 @@ module Zaikio
       test "without passing a ?state parameter, it sets a high-entropy string cookie" do
         get zaikio_oauth_client.new_subscription_path
 
-        jar = ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
-        assert jar.encrypted["state"].present?
-        assert jar.encrypted["state"].length > 30
+        current_response = response
 
-        authorize_url = URI.parse(response.headers["Location"])
+        assert get_session(:state).present?
+        assert get_session(:state).length > 30
+
+        authorize_url = URI.parse(current_response.headers["Location"])
         authorize_params = URI.decode_www_form(authorize_url.query).to_h
-        assert_equal jar.encrypted["state"], authorize_params["state"]
+        assert_equal get_session(:state), authorize_params["state"]
       end
     end
   end

--- a/test/dummy/app/controllers/welcomes_controller.rb
+++ b/test/dummy/app/controllers/welcomes_controller.rb
@@ -1,4 +1,5 @@
 class WelcomesController < ApplicationController
   def index
+    render plain: "Hello #{session[:zaikio_person_id]}"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,3 +18,9 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.file_fixture_path = File.join(ActiveSupport::TestCase.fixture_path, "files")
   ActiveSupport::TestCase.fixtures :all
 end
+
+require "zaikio/oauth_client/test_helper"
+
+class ActionDispatch::IntegrationTest
+  include Zaikio::OAuthClient::TestHelper
+end

--- a/test/zaikio/oauth_client/test_helper_test.rb
+++ b/test/zaikio/oauth_client/test_helper_test.rb
@@ -2,15 +2,13 @@ require "test_helper"
 require "zaikio/oauth_client/test_helper"
 
 class Zaikio::OAuthClient::TestHelperTest < ActionDispatch::IntegrationTest
-  include Zaikio::OAuthClient::TestHelper
-
   test "sets cookie correctly" do
     person = OpenStruct.new(id: "my-id")
     logged_in_as(person)
 
     get "/"
 
-    jar = ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
-    assert_equal "my-id", jar.encrypted["zaikio_person_id"]
+    assert_equal "Hello my-id", response.body
+    assert_equal "my-id", @controller.session[:zaikio_person_id]
   end
 end


### PR DESCRIPTION
Breaking Change that moves from cookies to session in order to enforce `httponly` on these sensitive data.

Sadly - after endless research - I wasn't able to have a proper way to access the `session` in the tests. The best way was still to add a dummy controller that handles that. If you have a better suggestion, I would be happy to implement it.