### PR TITLE
Add SystemTestHelper for easier test setup & bump version to v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.12.1 - 2021-04-23
+
+* Add `Zaikio::OAuthClient::SystemTestHelper` for working with system tests
+  ([instructions here](https://github.com/zaikio/zaikio-oauth_client/blob/main/README.md#testing))
+
 ## 0.12.0 - 2021-04-23
 
 * **BREAKING CHANGE:** Instead of working `cookies.encrypted` we will switch to `session` because the session cookie will be `httponly` and therefore can prevent XSS attack that set the cookie to another value. See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zaikio-oauth_client (0.12.0)
+    zaikio-oauth_client (0.12.1)
       actionpack (>= 5.0.0)
       activerecord (>= 5.0.0)
       activesupport (>= 5.0.0)

--- a/README.md
+++ b/README.md
@@ -239,6 +239,21 @@ class MyControllerTest < ActionDispatch::IntegrationTest
 end
 ```
 
+For system tests (e.g. with a separate browser instance), there's a special helper:
+
+```rb
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  include Zaikio::OAuthClient::SystemTestHelper
+
+  test "does request" do
+    person = people(:my_person)
+    logged_in_as(person)
+
+    visit "/"
+  end
+end
+```
+
 #### Authenticated requests
 
 Now further requests to the Directory API or to other Zaikio APIs should be made. For this purpose the OAuthClient provides a helper method `with_auth` that automatically fetches an access token from the database, requests a refresh token or creates a new access token via client credentials flow.

--- a/lib/zaikio/oauth_client/system_test_helper.rb
+++ b/lib/zaikio/oauth_client/system_test_helper.rb
@@ -1,0 +1,18 @@
+require_relative "./test_helper"
+
+module Zaikio
+  module OAuthClient
+    module SystemTestHelper
+      include ::Zaikio::OAuthClient::TestHelper
+
+      def set_session(key, value)
+        visit "/zaikio/oauth_client/test_helper/session?#{{ key: key, id: value }.to_query}"
+      end
+
+      def get_session(key)
+        visit "/zaikio/oauth_client/test_helper/get_session?#{{ key: key }.to_query}"
+        page.text
+      end
+    end
+  end
+end

--- a/lib/zaikio/oauth_client/version.rb
+++ b/lib/zaikio/oauth_client/version.rb
@@ -1,5 +1,5 @@
 module Zaikio
   module OAuthClient
-    VERSION = "0.12.0".freeze
+    VERSION = "0.12.1".freeze
   end
 end


### PR DESCRIPTION
This is necessary because we can't use all of the regular test helper in system tests (there is no `#get(...)` method defined for example). Instead we make the browser visit those pages and inspect the response text.