### PR TITLE
Better handling of ?lang parameter when starting OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* Allow passing `?lang` when starting a new OAuth session
+* Allow passing `?lang`, or set the default to `I18n.locale`, when starting a new OAuth session
 
 ## 0.12.1 - 2021-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Allow passing `?lang` when starting a new OAuth session
+
 ## 0.12.1 - 2021-04-23
 
 * Add `Zaikio::OAuthClient::SystemTestHelper` for working with system tests

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -4,7 +4,7 @@ module Zaikio
       extend ActiveSupport::Concern
 
       def new
-        opts = params.permit(:client_name, :show_signup, :force_login, :state)
+        opts = params.permit(:client_name, :show_signup, :force_login, :state, :lang)
         opts[:redirect_with_error] = 1
         client_name = opts.delete(:client_name)
         opts[:state] ||= session[:state] = SecureRandom.urlsafe_base64(32)

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -6,6 +6,7 @@ module Zaikio
       def new
         opts = params.permit(:client_name, :show_signup, :force_login, :state, :lang)
         opts[:redirect_with_error] = 1
+        opts[:lang] ||= I18n.locale if defined?(I18n)
         client_name = opts.delete(:client_name)
         opts[:state] ||= session[:state] = SecureRandom.urlsafe_base64(32)
 

--- a/test/controllers/zaikio/oauth_client/connections_controller_test.rb
+++ b/test/controllers/zaikio/oauth_client/connections_controller_test.rb
@@ -29,7 +29,8 @@ module Zaikio
           redirect_with_error: 1,
           response_type: "code",
           scope: "Org.directory.organization.r",
-          state: ""
+          state: "",
+          lang: "en"
         }
 
         assert_redirected_to "http://hub.zaikio.test/oauth/authorize?#{params.to_query}"
@@ -44,7 +45,8 @@ module Zaikio
           redirect_with_error: 1,
           response_type: "code",
           scope: "Org/123.directory.organization.r",
-          state: "yes-me"
+          state: "yes-me",
+          lang: "en"
         }
 
         assert_redirected_to "http://hub.zaikio.test/oauth/authorize?#{params.to_query}"

--- a/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
+++ b/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
@@ -59,6 +59,24 @@ module Zaikio
         assert_redirected_to "http://hub.zaikio.test/oauth/authorize?#{params.to_query}"
       end
 
+      test "?lang is set to I18n.locale if none other given" do
+        I18n.with_locale(:de) do
+          get zaikio_oauth_client.new_session_path(state: "entropy")
+        end
+
+        params = {
+          client_id: "abc",
+          redirect_uri: zaikio_oauth_client.approve_session_url,
+          redirect_with_error: 1,
+          response_type: "code",
+          scope: "directory.person.r",
+          state: "entropy",
+          lang: "de"
+        }
+
+        assert_redirected_to "http://hub.zaikio.test/oauth/authorize?#{params.to_query}"
+      end
+
       test "Shows error and redirects if redirect flow wasn't successful" do
         get approve_session_path(error: "invalid_request", error_description: "My Error")
 

--- a/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
+++ b/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
@@ -41,6 +41,7 @@ module Zaikio
         get zaikio_oauth_client.new_session_path(show_signup: true,
                                                  force_login: true,
                                                  state: "entropy",
+                                                 lang: "de",
                                                  unknown_param: :no)
 
         params = {
@@ -51,7 +52,8 @@ module Zaikio
           scope: "directory.person.r",
           show_signup: true,
           force_login: true,
-          state: "entropy"
+          state: "entropy",
+          lang: "de"
         }
 
         assert_redirected_to "http://hub.zaikio.test/oauth/authorize?#{params.to_query}"


### PR DESCRIPTION
1. Allow passing `?lang` to `new_session_path` and others
2. Default that value to `I18n.locale`, which means the Hub activity will use the same locale as the calling application automatically.