### PR TITLE
Support prompt option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Support `prompt` option for SSO
 * Remove `redirect_with_error=1` since it is now the default and deprecated.
 
 ## 0.13.0 - 2021-04-28

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -4,7 +4,7 @@ module Zaikio
       extend ActiveSupport::Concern
 
       def new
-        opts = params.permit(:client_name, :show_signup, :force_login, :state, :lang)
+        opts = params.permit(:client_name, :show_signup, :prompt, :force_login, :state, :lang)
         opts[:lang] ||= I18n.locale if defined?(I18n)
         client_name = opts.delete(:client_name)
         opts[:state] ||= session[:state] = SecureRandom.urlsafe_base64(32)

--- a/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
+++ b/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
@@ -41,6 +41,7 @@ module Zaikio
                                                  force_login: true,
                                                  state: "entropy",
                                                  lang: "de",
+                                                 prompt: "select_account",
                                                  unknown_param: :no)
 
         params = {
@@ -51,7 +52,8 @@ module Zaikio
           show_signup: true,
           force_login: true,
           state: "entropy",
-          lang: "de"
+          lang: "de",
+          prompt: "select_account"
         }
 
         assert_redirected_to "http://hub.zaikio.test/oauth/authorize?#{params.to_query}"


### PR DESCRIPTION
(Also `show_signup` will be dropped soon in favour of `prompt=signup`)