### PR TITLE
Fix circleci fails: update apt-get

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
           paths:
             - /home/circleci/project/test/dummy/public/packs-test/
 
+      - run: sudo apt-get update
       - run: sudo apt install postgresql-client
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run: bundle exec rake db:create


### PR DESCRIPTION
see e.g. https://app.circleci.com/pipelines/github/zaikio/zaikio-oauth_client/586/workflows/0c340dfd-d843-42b6-8b26-598124e81919/jobs/610 (happened multiple times in a row)

fix from this thread: https://discuss.circleci.com/t/random-404-when-doing-apt-get-install-postgresql-client/30286