### PR TITLE
Don't return access tokens which expire in <30s, and allow setting this

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Don't return access tokens which are due to expire in <30 seconds from now, and allow
+  configuring this property with the `valid_for` keyword argument.
+
 ## 0.14.0 - 2021-06-18
 
 * Support `prompt` option for SSO

--- a/README.md
+++ b/README.md
@@ -266,6 +266,18 @@ Zaikio::OAuthClient.with_auth(bearer_type: "Organization", bearer_id: "fd61f5f5-
 end
 ```
 
+If you need the token for a certain period (e.g. a long-running job which makes many
+requests in sequence), you can specify the `valid_for` interval when requesting the token.
+By default, it won't return an access token which was due to expire in less than 30
+seconds from now. If there is an existing token, but it was due to expire before the end
+of the validity period, this will go and get a fresh token anyway:
+
+```rb
+Zaikio::OAuthClient.with_auth(..., valid_for: 10.minutes) do |access_token|
+  # ...
+end
+```
+
 ## Use of dummy app
 
 You can use the included dummy app as a showcase for the workflow and to adjust your own application. To set up the dummy application properly, go into `test/dummy` and use [puma-dev](https://github.com/puma/puma-dev) like this:

--- a/lib/zaikio/oauth_client.rb
+++ b/lib/zaikio/oauth_client.rb
@@ -62,7 +62,7 @@ module Zaikio
       #   * If the token has expired, it will be refreshed using the refresh_token flow
       #     (if this fails, we fallback to getting a new token using client_credentials)
       #   * If the token does not exist, we'll get a new one using the client_credentials flow
-      def get_access_token(bearer_id:, client_name: nil, bearer_type: "Person", scopes: nil)
+      def get_access_token(bearer_id:, client_name: nil, bearer_type: "Person", scopes: nil, valid_for: 30.seconds)
         client_config = client_config_for(client_name || self.client_name)
         scopes ||= client_config.default_scopes_for(bearer_type)
 
@@ -71,7 +71,7 @@ module Zaikio
                                          bearer_id: bearer_id,
                                          requested_scopes: scopes)
 
-        token = token.refresh! if token&.expired?
+        token = token.refresh! if token && (token.expired? || token.expires_at < valid_for.from_now)
 
         token ||= fetch_new_token(client_config: client_config,
                                   bearer_type: bearer_type,

--- a/test/zaikio/oauth_client_test.rb
+++ b/test/zaikio/oauth_client_test.rb
@@ -208,6 +208,58 @@ class Zaikio::OAuthClient::Test < ActiveSupport::TestCase
     assert_not_equal access_token, refreshed_token
   end
 
+  test "generates refresh token if expires before valid_for argument" do
+    Zaikio::JWTAuth.stubs(:revoked_token_ids).returns([])
+    access_token = Zaikio::AccessToken.create!(
+      bearer_type: "Organization",
+      bearer_id: "123",
+      audience: "warehouse",
+      token: "abc",
+      refresh_token: "def",
+      expires_at: 5.minutes.from_now,
+      scopes: %w[directory.organization.r directory.something.r],
+      requested_scopes: %w[directory.organization.r directory.something.r]
+    )
+
+    stub_request(:post, "http://hub.zaikio.test/oauth/access_token")
+      .with(
+        basic_auth: %w[abc secret],
+        body: {
+          "grant_type" => "refresh_token",
+          "refresh_token" => access_token.refresh_token
+        },
+        headers: {
+          "Accept" => "application/json"
+        }
+      )
+      .to_return(status: 200, body: {
+        "access_token" => "refreshed",
+        "refresh_token" => "refresh_of_refreshed",
+        "token_type" => "bearer",
+        "scope" => "directory.organization.r,directory.something.r",
+        "audiences" => ["warehouse"],
+        "expires_in" => 600,
+        "bearer" => {
+          id: "123",
+          type: "Organization"
+        }
+      }.to_json, headers: { "Content-Type" => "application/json" })
+
+    refreshed_token = Zaikio::OAuthClient.get_access_token(
+      bearer_type: "Organization",
+      bearer_id: "123",
+      scopes: %w[directory.something.r],
+      valid_for: 10.minutes
+    )
+    assert_not refreshed_token.expired?
+    assert_equal %w[directory.organization.r directory.something.r], refreshed_token.scopes
+    assert_equal "123", refreshed_token.bearer_id
+    assert_equal "Organization", refreshed_token.bearer_type
+    assert_equal "refreshed", refreshed_token.token
+    assert_equal "refresh_of_refreshed", refreshed_token.refresh_token
+    assert_not_equal access_token, refreshed_token
+  end
+
   test "when refreshing fails, fallback to client_credentials flow" do
     Zaikio::JWTAuth.stubs(:revoked_token_ids).returns([])
     access_token = Zaikio::AccessToken.create!(


### PR DESCRIPTION
I encounted an issue where we fetched a usable access token which was due to expire in one second. Since my usage is catching all HTTP errors, I would need to detect the 403-specific error and do something differently.

Instead, it would be better to specify a "lease time" when getting the token - I know approximately how long I would need the token for, so I will request a token which has enough "lease" left on it to fulfil my needs.

This change will probably lead to a small increase in the number of tokens in the system, because we'll be proactively refreshing tokens before their official expiration. However, this tradeoff means that it is less likely to encounter the issue of an expired token mid-process. `30.seconds` might not be the perfect duration, I'm open to suggestions!