### PR TITLE
Fix issue when trying to refresh a token that has `refresh_token: nil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Consider `valid_for` when fetching AccessTokens from the database, and only return
+  tokens which meet the expected validity period.
+
 ## 0.15.0 - 2021-08-13
 
 * Don't return access tokens which are due to expire in <30 seconds from now, and allow

--- a/lib/zaikio/oauth_client.rb
+++ b/lib/zaikio/oauth_client.rb
@@ -69,9 +69,10 @@ module Zaikio
         token = find_usable_access_token(client_name: client_config.client_name,
                                          bearer_type: bearer_type,
                                          bearer_id: bearer_id,
-                                         requested_scopes: scopes)
+                                         requested_scopes: scopes,
+                                         valid_for: valid_for)
 
-        token = token.refresh! if token && (token.expired? || token.expires_at < valid_for.from_now)
+        token = token.refresh! if token&.expired?
 
         token ||= fetch_new_token(client_config: client_config,
                                   bearer_type: bearer_type,
@@ -82,7 +83,7 @@ module Zaikio
 
       # Finds the best usable access token. Note that this token may have expired and
       # would require refreshing.
-      def find_usable_access_token(client_name:, bearer_type:, bearer_id:, requested_scopes:)  # rubocop:disable Metrics/MethodLength
+      def find_usable_access_token(client_name:, bearer_type:, bearer_id:, requested_scopes:, valid_for: 30.seconds)  # rubocop:disable Metrics/MethodLength
         configuration.logger.debug "Try to fetch token for client_name: #{client_name}, "\
                                    "bearer #{bearer_type}/#{bearer_id}, requested_scopes: #{requested_scopes}"
 
@@ -92,7 +93,8 @@ module Zaikio
             .usable(
               bearer_type: bearer_type,
               bearer_id: bearer_id,
-              requested_scopes: requested_scopes
+              requested_scopes: requested_scopes,
+              valid_until: valid_for.from_now
             )
             .first
         }


### PR DESCRIPTION
Seeing this a lot in the logs:

```
A refresh_token is not available
```

This happens because of this block. When `refresh_token` is `nil`, this block fails:

```
refreshed_token = OAuth2::AccessToken.from_hash(
  Zaikio::OAuthClient.for(audience),
  attributes.slice("token", "refresh_token")
).refresh!
```

We should not try to `#refresh!` our tokens if there is no `refresh_token` set. This can happen if the `valid_for` period is not considered when fetching a token (fixed here), or if it found a client credentials token by change (fixed here).