### PR TITLE
Retry SSO-flow if code is not valid (anymore)

### DIFF
--- a/app/controllers/zaikio/oauth_client/connections_controller.rb
+++ b/app/controllers/zaikio/oauth_client/connections_controller.rb
@@ -5,6 +5,10 @@ module Zaikio
 
       private
 
+      def new_path(options = {})
+        zaikio_oauth_client.new_connection_path(options)
+      end
+
       def approve_url(client_name = nil)
         zaikio_oauth_client.approve_connection_url(client_name)
       end

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -37,6 +37,7 @@ module Zaikio
 
         origin = session[:origin]
         session.delete(:origin)
+        session.delete(:oauth_attempts)
 
         session[:zaikio_access_token_id] = access_token.id unless access_token.organization?
 
@@ -46,6 +47,9 @@ module Zaikio
         )
       rescue OAuth2::Error => e
         raise e unless e.code == "invalid_grant"
+        raise e if session[:oauth_attempts].to_i >= 3
+
+        session[:oauth_attempts] = session[:oauth_attempts].to_i + 1
 
         redirect_to new_path(client_name: params[:client_name])
       end

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -17,7 +17,7 @@ module Zaikio
         )
       end
 
-      def approve  # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+      def approve  # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
         if params[:error].present?
           redirect_to send(
             respond_to?(:error_path_for) ? :error_path_for : :default_error_path_for,
@@ -44,6 +44,10 @@ module Zaikio
           respond_to?(:after_approve_path_for) ? :after_approve_path_for : :default_after_approve_path_for,
           access_token, origin
         )
+      rescue OAuth2::Error => e
+        raise e unless e.code == "invalid_grant"
+
+        redirect_to new_path(client_name: params[:client_name])
       end
 
       def destroy
@@ -58,6 +62,10 @@ module Zaikio
       end
 
       private
+
+      def new_path(options = {})
+        zaikio_oauth_client.new_session_path(options)
+      end
 
       def approve_url(client_name = nil)
         zaikio_oauth_client.approve_session_url(client_name)

--- a/test/controllers/zaikio/oauth_client/connections_controller_test.rb
+++ b/test/controllers/zaikio/oauth_client/connections_controller_test.rb
@@ -63,6 +63,13 @@ module Zaikio
         get approve_connection_path(code: "expiredcode")
 
         assert_redirected_to zaikio_oauth_client.new_connection_path
+
+        # Retries multiple times
+        get approve_connection_path(code: "expiredcode")
+        get approve_connection_path(code: "expiredcode")
+        assert_raise OAuth2::Error do
+          get approve_connection_path(code: "expiredcode")
+        end
       end
 
       test "without passing a ?state parameter, it sets a high-entropy string cookie" do


### PR DESCRIPTION
Should fix https://github.com/zaikio/zai-procurement/issues/2903

When refreshing the page or the code expired we should retry the SSO flow. In case this leads to an endless loop we would see a rate limit error pretty soon.