### PR TITLE
Set `allow_other_host: true` when redirecting to Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * Retry SSO-flow if code is not given
+* Set `allow_other_host: true` when redirecting to Hub (required for Rails 7 strict
+  redirect policy). This property is backwards-compatible with older versions, it's only
+  used in Rails 7+ when `ActionController::Base.raise_on_open_redirects = true` is set.
 
 ## 0.17.0 - 2021-09-23
 

--- a/app/controllers/zaikio/oauth_client/subscriptions_controller.rb
+++ b/app/controllers/zaikio/oauth_client/subscriptions_controller.rb
@@ -20,7 +20,7 @@ module Zaikio
           redirect_uri: approve_url(opts.delete(:client_name)),
           scope: subscription_scope,
           **opts
-        )
+        ), allow_other_host: true
       end
     end
   end

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -14,7 +14,7 @@ module Zaikio
           redirect_uri: approve_url(client_name),
           scope: oauth_scope,
           **opts
-        )
+        ), allow_other_host: true
       end
 
       def approve  # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -7,7 +7,7 @@ Bundler.require(*Rails.groups)
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
This is required in Rails 7 if using the `ActionController::Base.raise_on_open_redirects` configuration flag (which is the default). Otherwise, Rails will throw an `ActionController::Redirecting::UnsafeRedirectError` for us. [Documentation](https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to).

I think these are the only two places where this client redirects _away_ from the parent application to the Hub - the other redirects are presumably internal.