### PR TITLE
Improve security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Do not store refresh tokens from client credentials flow to improve security ([until they are removed by the hub](https://docs.zaikio.com/changelog/2022-08-09_client-credentials-drop-refresh-token.html))
+* Do not redeem refresh tokens in `get_access_token` instead use client credentials flow so that only users redeem refresh tokens
+* Automatically revoke access token on logout (security)
+* Add `Zaikio::OAuthClient.find_active_access_token( session[:zaikio_access_token_id])` that should be used to find the latest valid access token. If the (redirect) access token e.g. was revoked (user disconnected, security breach, ...) the user shall be logged out.
+* Add `Zaikio::AccessToken#revoke!`
+
 ## 0.18.1 - 2022-04-29
 
 * Relax dependency on `zaikio-jwt_auth`, allow versions 2.x

--- a/README.md
+++ b/README.md
@@ -145,12 +145,19 @@ redirect_to zaikio_oauth_client.new_subscription_path(plan: "free")
 
 #### Session handling
 
-The Zaikio gem engine will set a cookie for the user after a successful OAuth flow: `session[:zaikio_person_id]`.
+The Zaikio gem engine will set a cookie for the access token after a successful OAuth flow: `session[:zaikio_access_token_id]`.
 
 If you are using for example `Zaikio::Hub::Models`, you can use this snippet to set the current user:
 
 ```ruby
-Current.user ||= Zaikio::Hub::Models::Person.find_by(id: session[:zaikio_person_id])
+access_token = Zaikio::OAuthClient.find_active_access_token(, session[:zaikio_access_token_id])
+session[:zaikio_access_token_id] = access_token&.id
+Current.user = Zaikio::Hub::Models::Person.find_by(id: access_token&.bearer_id)
+
+unless Current.user
+  session[:origin] = request.fullpath
+  redirect_to zaikio_oauth_client.new_session_path
+end
 ````
 
 You can then use `Current.user` anywhere.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The Zaikio gem engine will set a cookie for the access token after a successful 
 If you are using for example `Zaikio::Hub::Models`, you can use this snippet to set the current user:
 
 ```ruby
-access_token = Zaikio::OAuthClient.find_active_access_token(, session[:zaikio_access_token_id])
+access_token = Zaikio::OAuthClient.find_active_access_token(session[:zaikio_access_token_id])
 session[:zaikio_access_token_id] = access_token&.id
 Current.user = Zaikio::Hub::Models::Person.find_by(id: access_token&.bearer_id)
 

--- a/app/models/zaikio/access_token.rb
+++ b/app/models/zaikio/access_token.rb
@@ -9,7 +9,7 @@ module Zaikio
     encrypts :token
     encrypts :refresh_token
 
-    def self.build_from_access_token(access_token, requested_scopes: nil, skip_refresh_token: false)
+    def self.build_from_access_token(access_token, requested_scopes: nil, include_refresh_token: true)
       payload = JWT.decode(access_token.token, nil, false).first rescue {} # rubocop:disable Style/RescueModifier
       scopes = access_token.params["scope"].split(",")
       new(
@@ -18,7 +18,7 @@ module Zaikio
         bearer_id: access_token.params["bearer"]["id"],
         audience: access_token.params["audiences"].first,
         token: access_token.token,
-        refresh_token: (access_token.refresh_token unless skip_refresh_token),
+        refresh_token: (access_token.refresh_token if include_refresh_token),
         expires_at: Time.strptime(access_token.expires_at.to_s, "%s"),
         scopes: scopes,
         requested_scopes: requested_scopes || scopes

--- a/app/models/zaikio/access_token.rb
+++ b/app/models/zaikio/access_token.rb
@@ -102,6 +102,8 @@ module Zaikio
       Zaikio::Hub.with_token(token) do
         Zaikio::Hub::RevokedAccessToken.create
       end
+    rescue Zaikio::ConnectionError => e
+      Zaikio::OAuthClient.configuration.logger.warn "Access Token #{id} could not be revoked: #{e.message}"
     end
   end
 end

--- a/lib/zaikio/oauth_client.rb
+++ b/lib/zaikio/oauth_client.rb
@@ -121,7 +121,7 @@ module Zaikio
             scopes: scopes
           ),
           requested_scopes: scopes,
-          skip_refresh_token: true
+          include_refresh_token: false
           # Do not store refresh token on client credentials flow
           # https://docs.zaikio.com/changelog/2022-08-09_client-credentials-drop-refresh-token.html
         ).tap(&:save!)

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -64,7 +64,7 @@ module Zaikio
 
         redirect_to send(
           respond_to?(:after_destroy_path_for) ? :after_destroy_path_for : :default_after_destroy_path_for,
-          session[:zaikio_access_token_id]
+          access_token.id
         )
       end
 

--- a/lib/zaikio/oauth_client/authenticatable.rb
+++ b/lib/zaikio/oauth_client/authenticatable.rb
@@ -55,13 +55,16 @@ module Zaikio
       end
 
       def destroy
-        access_token_id = session[:zaikio_access_token_id]
+        if (access_token = Zaikio::AccessToken.valid.or(Zaikio::AccessToken.valid_refresh)
+                                             .find_by(id: session[:zaikio_access_token_id]))
+          access_token.revoke!
+        end
         session.delete(:zaikio_access_token_id)
         session.delete(:origin)
 
         redirect_to send(
           respond_to?(:after_destroy_path_for) ? :after_destroy_path_for : :default_after_destroy_path_for,
-          access_token_id
+          session[:zaikio_access_token_id]
         )
       end
 

--- a/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
+++ b/test/controllers/zaikio/oauth_client/sessions_controller_test.rb
@@ -130,6 +130,7 @@ module Zaikio
       end
 
       test "Does code grant flow" do
+        Zaikio::JWTAuth.stubs(:revoked_token_ids).returns([])
         set_session(:origin, "/?a=b")
 
         stub_request(:post, "http://hub.zaikio.test/oauth/access_token")
@@ -172,6 +173,10 @@ module Zaikio
         assert_equal "be4ae927cf49466293049c993ad911b2", access_token.refresh_token
         assert_equal %w[directory.person.r], access_token.scopes
 
+        Zaikio::Hub = Module.new
+        Zaikio::Hub::RevokedAccessToken = Class.new
+        Zaikio::Hub.stubs(:with_token).with("749ceefd1f7909a1773501e0bc57d5b2").yields
+        Zaikio::Hub::RevokedAccessToken.expects(:create)
         delete zaikio_oauth_client.session_path(client_name: "warehouse")
         jar = ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
         assert_nil jar.encrypted["zaikio_person_id"]

--- a/test/models/zaikio/access_token_test.rb
+++ b/test/models/zaikio/access_token_test.rb
@@ -2,8 +2,51 @@ require "test_helper"
 
 module Zaikio
   class AcessTokenTest < ActiveSupport::TestCase
-    # test "the truth" do
-    #   assert true
-    # end
+    test "#refresh!" do
+      Zaikio::JWTAuth.stubs(:revoked_token_ids).returns([])
+      access_token = Zaikio::AccessToken.create!(
+        bearer_type: "Organization",
+        bearer_id: "123",
+        audience: "warehouse",
+        token: "abc",
+        refresh_token: "def",
+        expires_at: 1.hour.ago,
+        scopes: %w[directory.organization.r directory.something.r],
+        requested_scopes: %w[directory.organization.r directory.something.r]
+      )
+
+      stub_request(:post, "http://hub.zaikio.test/oauth/access_token")
+        .with(
+          basic_auth: %w[abc secret],
+          body: {
+            "grant_type" => "refresh_token",
+            "refresh_token" => access_token.refresh_token
+          },
+          headers: {
+            "Accept" => "application/json"
+          }
+        )
+        .to_return(status: 200, body: {
+          "access_token" => "refreshed",
+          "refresh_token" => "refresh_of_refreshed",
+          "token_type" => "bearer",
+          "scope" => "directory.organization.r,directory.something.r",
+          "audiences" => ["warehouse"],
+          "expires_in" => 600,
+          "bearer" => {
+            id: "123",
+            type: "Organization"
+          }
+        }.to_json, headers: { "Content-Type" => "application/json" })
+
+      refreshed_token = access_token.refresh!
+      assert_not refreshed_token.expired?
+      assert_equal %w[directory.organization.r directory.something.r], refreshed_token.scopes
+      assert_equal "123", refreshed_token.bearer_id
+      assert_equal "Organization", refreshed_token.bearer_type
+      assert_equal "refreshed", refreshed_token.token
+      assert_equal "refresh_of_refreshed", refreshed_token.refresh_token
+      assert_not_equal access_token, refreshed_token
+    end
   end
 end


### PR DESCRIPTION
* Do not store refresh tokens from client credentials flow to improve security ([until they are removed by the hub](https://docs.zaikio.com/changelog/2022-08-09_client-credentials-drop-refresh-token.html))
* Do not redeem refresh tokens in `get_access_token` instead use client credentials flow so that only users redeem refresh tokens
* Automatically revoke access token on logout (security)
* Add `Zaikio::OAuthClient.find_active_access_token(session[:zaikio_access_token_id])` that should be used to find the latest valid access token. If the (redirect) access token e.g. was revoked (user disconnected, security breach, ...) the user shall be logged out.
* Add `Zaikio::AccessToken#revoke!`