### PR TITLE
Fix logged_in_as helper to support access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Fix `logged_in_as` helper to create a proper access token
+
 ## 0.19.0 - 2022-08-03
 
 * Do not store refresh tokens from client credentials flow to improve security ([until they are removed by the hub](https://docs.zaikio.com/changelog/2022-08-09_client-credentials-drop-refresh-token.html))

--- a/lib/zaikio/oauth_client.rb
+++ b/lib/zaikio/oauth_client.rb
@@ -83,6 +83,11 @@ module Zaikio
       def find_active_access_token(id)
         return unless id
 
+        if Rails.env.test?
+          access_token = TestHelper.find_active_access_token(id)
+          return access_token if access_token
+        end
+
         access_token = Zaikio::AccessToken.find_by(id: id)
         access_token = access_token.refresh! if access_token&.expired?
 

--- a/lib/zaikio/oauth_client/test_helper.rb
+++ b/lib/zaikio/oauth_client/test_helper.rb
@@ -3,6 +3,23 @@ module Zaikio
     module TestHelper
       extend ActiveSupport::Concern
 
+      VirtualAccessToken = Struct.new(:bearer_id, :bearer_type, :audience, :expired?, keyword_init: true)
+
+      class << self
+        def find_active_access_token(id)
+          return unless id.to_s.starts_with?("AT:")
+
+          _, audience, person_id = id.split(":")
+
+          VirtualAccessToken.new(
+            bearer_id: person_id,
+            audience: audience,
+            bearer_type: "Person",
+            expired?: false
+          )
+        end
+      end
+
       class TestSessionController < ActionController::Base # rubocop:disable Rails/ApplicationController
         def show
           if session[params[:key]].nil?
@@ -43,7 +60,15 @@ module Zaikio
         get "/zaikio/oauth_client/test_helper/session", params: { id: value, key: key }
       end
 
-      def logged_in_as(person)
+      def logged_in_as(person, access_token: nil, client_name: nil)
+        client_name ||= Zaikio::OAuthClient.client_name ||
+                        Zaikio::OAuthClient.configuration.all_client_names.first
+        set_session(
+          :zaikio_access_token_id,
+          access_token&.id || "AT:#{client_name}:#{person.id}"
+        )
+
+        # Deprecated please use zaikio_access_token_id
         set_session(:zaikio_person_id, person.id)
       end
     end

--- a/test/zaikio/oauth_client/test_helper_test.rb
+++ b/test/zaikio/oauth_client/test_helper_test.rb
@@ -10,5 +10,10 @@ class Zaikio::OAuthClient::TestHelperTest < ActionDispatch::IntegrationTest
 
     assert_equal "Hello my-id", response.body
     assert_equal "my-id", @controller.session[:zaikio_person_id]
+    assert_equal "AT:warehouse:my-id", @controller.session[:zaikio_access_token_id]
+    access_token = Zaikio::OAuthClient.find_active_access_token(@controller.session[:zaikio_access_token_id])
+    assert_equal "my-id", access_token.bearer_id
+    assert_equal "Person", access_token.bearer_type
+    assert_not access_token.expired?
   end
 end


### PR DESCRIPTION
I decided to go for a virtual approach otherwise we would need to *create* actual entries in the DB which I think makes many tests very slow.