### PR TITLE
Refactor Zaikio::OAuthClient.client_name to be thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Refactor `Zaikio::OAuthClient.client_name` to be thread-safe
+
 ## 0.20.0 - 2022-08-08
 
 * Support prefilled person and organization data

--- a/lib/zaikio/oauth_client.rb
+++ b/lib/zaikio/oauth_client.rb
@@ -8,8 +8,6 @@ require "zaikio/oauth_client/authenticatable"
 module Zaikio
   module OAuthClient # rubocop:disable Metrics/ModuleLength
     class << self
-      attr_reader :client_name
-
       def configure
         @configuration ||= Configuration.new
         yield(configuration)
@@ -17,6 +15,14 @@ module Zaikio
 
       def configuration
         @configuration ||= Configuration.new
+      end
+
+      def client_name
+        Thread.current[:zaikio_oauth_client_name]
+      end
+
+      def client_name=(new_value)
+        Thread.current[:zaikio_oauth_client_name] = new_value
       end
 
       def for(client_name = nil)
@@ -34,12 +40,14 @@ module Zaikio
         @oauth_scheme = :request_body
       end
 
-      def with_client(client_name)
-        original_client_name = @client_name || nil
-        @client_name = client_name
+      def with_client(new_client_name)
+        original_client_name = client_name
+
+        self.client_name = new_client_name
+
         yield
       ensure
-        @client_name = original_client_name
+        self.client_name = original_client_name
       end
 
       def with_auth(options_or_access_token, &block)

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -19,10 +19,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_25_130923) do
     t.string "bearer_type", default: "Organization", null: false
     t.string "bearer_id", null: false
     t.string "audience", null: false
-    t.datetime "expires_at"
+    t.datetime "expires_at", precision: nil
     t.string "scopes", default: [], null: false, array: true
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "requested_scopes", default: [], null: false, array: true
     t.string "token", null: false
     t.string "refresh_token"


### PR DESCRIPTION
This now uses `Thread.current` instead of an instance variable on the eigenclass. It's not that thread-safety was an issue, but we're using this for the authorization middleware in the client helpers gem, so it's not only "better safe than sorry", but also consistency.