### PR TITLE
Fix access token lookup to use latest token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Fix: Use latest access token instead of first valid one in case user granted new permissions
+
 ## 0.21.1 - 2022-10-13
 
 * Fix `access_token` can be nil when deleting a session so add guard for this.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zaikio-oauth_client (0.20.0)
+    zaikio-oauth_client (0.21.1)
       actionpack (>= 5.0.0)
       activerecord (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -50,10 +50,10 @@ GEM
       rexml
     crass (1.0.6)
     erubi (1.11.0)
-    faraday (2.5.2)
+    faraday (2.6.0)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.0)
+    faraday-net_http (3.0.1)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -84,11 +84,11 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    oauth2 (2.0.8)
+    oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
       multi_xml (~> 0.5)
-      rack (>= 1.2, < 3)
+      rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
     oj (3.13.21)
@@ -158,9 +158,9 @@ GEM
       sprockets-rails
       tilt
     semantic_range (3.0.0)
-    snaky_hash (2.0.0)
+    snaky_hash (2.0.1)
       hashie
-      version_gem (~> 1.1)
+      version_gem (~> 1.1, >= 1.1.1)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -174,7 +174,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
-    version_gem (1.1.0)
+    version_gem (1.1.1)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)

--- a/lib/zaikio/oauth_client.rb
+++ b/lib/zaikio/oauth_client.rb
@@ -118,6 +118,7 @@ module Zaikio
               requested_scopes: requested_scopes
             )
             .valid(valid_for.from_now)
+            .order(created_at: :desc)
             .first
         }
 


### PR DESCRIPTION
This is actually a very interesting bug that occured in Keyline.

New permissions were granted for an organization but we still used a little bit older token that was leaking this new permissions:

**created through client credentials, has not the latest permissions but was used**
```rb
#<Zaikio::AccessToken:0x00007f5ca9b13638
  audience: "keyline_classic",
  expires_at: Tue, 18 Oct 2022 10:36:46.000000000 CEST +02:00,
  scopes: ["directory.organization.r", "directory.sites.rw", "procurement_consumer.contracts.rw", "procurement_consumer.orders.rw"],
  created_at: Tue, 18 Oct 2022 09:36:47.606289000 CEST +02:00,
  updated_at: Tue, 18 Oct 2022 09:36:47.606289000 CEST +02:00,
  requested_scopes:
   ["directory.organization.r",
    "directory.sites.rw",
    "directory.organization_members.rw",
    "procurement_consumer.orders.rw",
    "procurement_consumer.contracts.rw",
    "procurement_consumer.material_requirements.rw",
    "procurement_consumer.article_base.r",
    "warehouse.consumptions.rw",
    "warehouse.corrections.rw",
    "warehouse.deposits.rw",
    "warehouse.finished_goods_call_offs.r",
    "warehouse.manifest_entries.r",
    "warehouse.manifests.r",
    "warehouse.materials.rw",
    "warehouse.skus.rw",
    "warehouse.storage_areas.rw",
    "warehouse.warehouses.rw"],
  token: "[FILTERED]",
  refresh_token: nil>
```

**newer token created through redirect flow**

```rb
#<Zaikio::AccessToken:0x00007f5ca9687100
 audience: "keyline_classic",
 expires_at: Tue, 18 Oct 2022 10:57:10.000000000 CEST +02:00,
 scopes:
  ["directory.organization.r",
   "directory.organization_members.rw",
   "directory.sites.rw",
   "procurement_consumer.article_base.r",
   "procurement_consumer.contracts.rw",
   "procurement_consumer.material_requirements.rw",
   "procurement_consumer.orders.rw"],
 created_at: Tue, 18 Oct 2022 09:57:11.894980000 CEST +02:00,
 updated_at: Tue, 18 Oct 2022 09:57:11.894980000 CEST +02:00,
 requested_scopes:
  ["directory.organization.r",
   "directory.sites.rw",
   "directory.organization_members.rw",
   "procurement_consumer.orders.rw",
   "procurement_consumer.contracts.rw",
   "procurement_consumer.material_requirements.rw",
   "procurement_consumer.article_base.r",
   "warehouse.consumptions.rw",
   "warehouse.corrections.rw",
   "warehouse.deposits.rw",
   "warehouse.finished_goods_call_offs.r",
   "warehouse.manifest_entries.r",
   "warehouse.manifests.r",
   "warehouse.materials.rw",
   "warehouse.skus.rw",
   "warehouse.storage_areas.rw",
   "warehouse.warehouses.rw"],
 token: "[FILTERED]",
 refresh_token: "[FILTERED]">
```

The simple rule should just be: take the newest.